### PR TITLE
Update colorscheme.lua

### DIFF
--- a/lua/lazyvim/plugins/colorscheme.lua
+++ b/lua/lazyvim/plugins/colorscheme.lua
@@ -58,7 +58,7 @@ return {
         optional = true,
         opts = function(_, opts)
           if (vim.g.colors_name or ""):find("catppuccin") then
-            opts.highlights = require("catppuccin.groups.integrations.bufferline").get()
+            opts.highlights = require("catppuccin.groups.integrations.bufferline").get_theme()
           end
         end,
       },


### PR DESCRIPTION
latest change in cattpuccin has a breaking change on the integration method

## Description

after latest updates i did run into a weird bug that prevented bufferline to work. After some debuging i found the change in cattpuccin from 3 days ago and fixed in my fork

https://github.com/catppuccin/nvim/commit/30fa4d122d9b22ad8b2e0ab1b533c8c26c4dde86

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots


## Checklist

- [X] I've read the [CONTRIBUTING](https://github.com/LazyVim/LazyVim/blob/main/CONTRIBUTING.md) guidelines.
